### PR TITLE
Add additional parameter parsing to es-lint

### DIFF
--- a/modules/flamingo-carotene-es-lint/lib/handler/lint.js
+++ b/modules/flamingo-carotene-es-lint/lib/handler/lint.js
@@ -91,6 +91,12 @@ const getCommandParameters = function (config) {
     parameters.push('--ignore-path', config.eslint.ignoreFilePath)
   }
 
+  if (config.eslint.additionalShellParameters !== null) {
+    for (const param of config.eslint.additionalShellParameters) {
+      parameters.push(param)
+    }
+  }
+
   return parameters.concat([
     '--ext',
     '.js',


### PR DESCRIPTION
Adding the possibility to pass additional command-line parameters as an array to the es-lint configuration.