### PR TITLE
Make config.eslint.additionalShellParameters optional

### DIFF
--- a/modules/flamingo-carotene-es-lint/lib/handler/lint.js
+++ b/modules/flamingo-carotene-es-lint/lib/handler/lint.js
@@ -91,7 +91,7 @@ const getCommandParameters = function (config) {
     parameters.push('--ignore-path', config.eslint.ignoreFilePath)
   }
 
-  if (config.eslint.additionalShellParameters !== null) {
+  if (config.eslint.hasOwnProperty('additionalShellParameters') && config.eslint.additionalShellParameters !== null) {
     for (const param of config.eslint.additionalShellParameters) {
       parameters.push(param)
     }


### PR DESCRIPTION
`config.eslint.additionalShellParameters` should be optional. this change checks that the property is set, to prevent an error if not.