### PR TITLE
Update shelljs because of Node 14 Warnings

### DIFF
--- a/modules/flamingo-carotene-core/package.json
+++ b/modules/flamingo-carotene-core/package.json
@@ -28,7 +28,7 @@
     "intercept-stdout": "^0.1.2",
     "node-emoji": "^1.10.0",
     "progress": "^2.0.3",
-    "shelljs": "^0.8.2",
+    "shelljs": "^0.8.4",
     "word-wrap": "^1.2.3"
   }
 }


### PR DESCRIPTION
Installing flamingo-carotine-core and running carotine build outputs warnings, this is one of them: 
```
(node:42966) Warning: Accessing non-existent property 'touch' of module exports inside circular dependency
    at emitCircularRequireWarning (internal/modules/cjs/loader.js:823:11)
    at Object.get (internal/modules/cjs/loader.js:837:5)
    at Object._register [as register] (/Users/workspace/frontend/node_modules/flamingo-carotene-core/node_modules/shelljs/src/common.js:453:12)
    at Object.<anonymous> (/Users/workspace/frontend/node_modules/flamingo-carotene-core/node_modules/shelljs/src/touch.js:4:8)
    at Module._compile (internal/modules/cjs/loader.js:1200:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1220:10)
    at Module.load (internal/modules/cjs/loader.js:1049:32)
    at Function.Module._load (internal/modules/cjs/loader.js:937:14)
    at Module.require (internal/modules/cjs/loader.js:1089:19)
    at require (internal/modules/cjs/helpers.js:73:18)
```

I'm running Node 14.4. 
ShellJS fixed this problem with 0.8.4 https://github.com/shelljs/shelljs/issues/991.

