### PR TITLE
Bump version to 9.0.0-alpha.14 and update dependencies

### DIFF
--- a/modules/flamingo-carotene-core/package.json
+++ b/modules/flamingo-carotene-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flamingo-carotene-core",
-  "version": "9.0.0-alpha.13",
+  "version": "9.0.0-alpha.14",
   "description": "Core features for the Flamingo Carotene tooling",
   "author": "team-frontend <team-frontend@aoe.com>",
   "license": "OSL-3.0",
@@ -25,11 +25,12 @@
     "ansi-to-html": "0.7.2",
     "chalk": "4.1.2",
     "cli-progress": "3.12.0",
-    "cli-table3": "0.6.3",
+    "cli-table3": "0.6.5",
     "intercept-stdout": "0.1.2",
-    "node-emoji": "1.11.0",
+    "node-emoji": "2.2.0",
     "progress": "2.0.3",
-    "shelljs": "0.8.5",
+    "shelljs": "0.10.0",
     "word-wrap": "1.2.5"
-  }
+  },
+  "gitHead": "525073a8589c8d04fec95dddd7d751d5d6c05fa4"
 }


### PR DESCRIPTION
Updated package version and dependencies to latest versions.

"chalk": "4.1.2", need be old version 5+ version changed logics